### PR TITLE
Proposal for including dataset_description.json in skeleton

### DIFF
--- a/R/create_project_skeleton.R
+++ b/R/create_project_skeleton.R
@@ -48,7 +48,7 @@
 #' The following files are created (if not already present):
 #' \itemize{
 #'   \item `LICENSE` - CC BY 4.0 license text
-#'   \item `readme.md` - skeleton README describing project aims and structure
+#'   \item `README.md` - skeleton README describing project aims and structure
 #'   \item `dataset_description.json` - JSON-LD dataset metadata file
 #'   \item `.gitignore` - ignores R history, session data, caches, temp files,
 #'     OS-specific clutter, and large output directories
@@ -57,10 +57,6 @@
 #'   \item `code/processing.qmd` - Quarto processing template (same structure)
 #'   \item `tools/style_all_files.qmd` - reproducibility tool to apply
 #'     {tidyverse} code style to all `.qmd`, `.Rmd`, and `.R` files
-#'   \item `tools/detect_unused_dependencies.qmd` - reproducibility tool to
-#'     check whether there are unused dependencies in a project
-#'   \item `tools/detect_unused_objects.qmd` - reproducibility tool to
-#'     check whether there are unused objects in a project
 #' }
 #'
 #' Quarto `.qmd` files are pre-filled with:
@@ -77,24 +73,32 @@
 #'
 #' @examples
 #' \dontrun{
-#' # Create a skeleton in a parent directory with interactive prompts
+#' # Create a skeleton in a parent directory
 #' create_project_skeleton(project_root = "../", overwrite = FALSE)
 #'
-#' # Create with specified name and description
-#' create_project_skeleton(
-#'   project_root = ".", 
-#'   overwrite = TRUE,
-#'   project_name = "My Research Study",
-#'   project_description = "A longitudinal study examining cognitive development"
-#' )
+#' # Create in the current working directory and overwrite any existing templates
+#' create_project_skeleton(project_root = ".", overwrite = TRUE)
 #' 
 #' # Create in a specified directory
 #' create_project_skeleton("~/path/to/github_repository_name", overwrite = FALSE)
+#' 
+#' # Create with specified name and description
+#' create_project_skeleton(
+#'   project_root = ".", 
+#'   project_name = "My Research Study",
+#'   project_description = "A longitudinal study examining cognitive development"
+#' )
 #' }
 #'
 #' @seealso [psych-DS specification](https://psych-ds.github.io/)
 #'
 #' @export
+
+# \item `tools/detect_unused_dependencies.qmd` - reproducibility tool to
+#   check whether there are unused dependencies in a project
+# \item `tools/detect_unused_objects.qmd` - reproducibility tool to
+#   check whether there are unused objects in a project
+
 create_project_skeleton <- function(project_root = "../", overwrite = FALSE, 
                                     project_name = NULL, project_description = NULL) {
   # minimal dependencies: base R only
@@ -167,7 +171,7 @@ create_project_skeleton <- function(project_root = "../", overwrite = FALSE,
   # helper for string concatenation
   `%+%` <- function(a, b) paste0(a, b)
   
-  readme_path <- join(project_root, "readme.md")
+  readme_path <- join(project_root, "README.md")
   readme_text <- paste(
     "# Project Title",
     "",
@@ -190,7 +194,7 @@ create_project_skeleton <- function(project_root = "../", overwrite = FALSE,
       "methods/              # measures, implementations (qualtrics, lab.js, psychopy files, etc.), .docx files with items, etc.\n" %+%
       "preregistration/      # preregistration documents\n" %+%
       "LICENSE               # suggested: CC BY 4.0\n" %+%
-      "readme.md             # this file\n" %+%
+      "README.md             # this file\n" %+%
       "```",
     "",
     "## Reproducibility",
@@ -317,6 +321,36 @@ create_project_skeleton <- function(project_root = "../", overwrite = FALSE,
     write_if_absent(join(project_root, rel), qmd_header(gsub("^code/|\\.qmd$", "", rel)))
   }))
   
+  # --- tools/project_validator.qmd ---
+  tools_validator_qmd_path <- join(project_root, "tools", "project_validator.qmd")
+  tools_validator_qmd_text <- paste(
+    "---",
+    'title: "Check repository compliance against psych-ds-ish standard"',
+    "format:",
+    "  html:",
+    "    toc: true",
+    "    code-fold: true",
+    "execute:",
+    "  warning: false",
+    "  message: false",
+    "---",
+    "",
+    "```{r}",
+    "",
+    "library(psychdsish)",
+    "library(knitr)",
+    "library(kableExtra)",
+    "",
+    'results <- validator("../")',
+    "",
+    "results |>",
+    "  knitr::kable() |>",
+    "  kableExtra::kable_classic(full_width = FALSE)",
+    "```",
+    sep = "\n"
+  )
+  write_if_absent(tools_validator_qmd_path, tools_validator_qmd_text)
+  
   # --- tools/style_all_files.qmd ---
   tools_style_qmd_path <- join(project_root, "tools", "style_all_files.qmd")
   tools_style_qmd_text <- paste(
@@ -343,72 +377,72 @@ create_project_skeleton <- function(project_root = "../", overwrite = FALSE,
   write_if_absent(tools_style_qmd_path, tools_style_qmd_text)
   
   
-  # --- tools/detect_unused_dependencies.qmd ---
-  tools_dependencies_qmd_path <- join(project_root, "tools", "check_unused_dependencies.qmd")
-  tools_dependencies_qmd_text <- paste(
-    "---",
-    'title: "Check if there are unused dependencies in a project"',
-    "format:",
-    "  html:",
-    "    toc: true",
-    "    code-fold: true",
-    "execute:",
-    "  warning: false",
-    "  message: false",
-    "---",
-    "",
-    "```{r}",
-    "",
-    "library(psychdsish)",
-    "library(knitr)",
-    "library(kableExtra)",
-    "",
-    "res <- check_unused_dependencies(root = '../')",
-    "",
-    "res |>",
-    "  kable() |>",
-    "  kable_classic(full_width = FALSE)",
-    "",
-    "```",
-    sep = "\n"
-  )
-  write_if_absent(tools_dependencies_qmd_path, tools_dependencies_qmd_text)
-  
-  
-  # --- tools/check_unused_objects.qmd ---
-  tools_unused_objects_qmd_path <- join(project_root, "tools", "check_unused_objects.qmd")
-  tools_unused_objects_qmd_text <- paste(
-    "---",
-    'title: "Check if there are unused objects in a project"',
-    "format:",
-    "  html:",
-    "    toc: true",
-    "    code-fold: true",
-    "execute:",
-    "  warning: false",
-    "  message: false",
-    "---",
-    "",
-    "When learning to code, it's very easy to accidentally create objects (e.g., data frames) and then never use them in your code. Sometimes, users create 'df2' from 'df1' but, later in the code, go back to calling 'df1'. These 'orphan' objects can represent errors or generally make code confusing - why create an object that is never used?",
-    "",
-    "This function lets you scan all .qmd, .Rmd, and .R files in your project for unused 'orphan' objects. If you find your project contains them, you should think about whether they're redundant and can be removed, or whether maybe you have an error (e.g., maybe subsequent code should call these objects and not others).",
-    "",
-    "```{r}",
-    "",
-    "library(psychdsish)",
-    "library(knitr)",
-    "library(kableExtra)",
-    "",
-    "res <- check_unused_objects(root = '../')",
-    "",
-    "res |>",
-    "  kable() |>",
-    "  kable_classic(full_width = FALSE)",
-    "",
-    "```",
-    sep = "\n"
-  )
-  write_if_absent(tools_unused_objects_qmd_path, tools_unused_objects_qmd_text)
+  # # --- tools/detect_unused_dependencies.qmd ---
+  # tools_dependencies_qmd_path <- join(project_root, "tools", "check_unused_dependencies.qmd")
+  # tools_dependencies_qmd_text <- paste(
+  #   "---",
+  #   'title: "Check if there are unused dependencies in a project"',
+  #   "format:",
+  #   "  html:",
+  #   "    toc: true",
+  #   "    code-fold: true",
+  #   "execute:",
+  #   "  warning: false",
+  #   "  message: false",
+  #   "---",
+  #   "",
+  #   "```{r}",
+  #   "",
+  #   "library(psychdsish)",
+  #   "library(knitr)",
+  #   "library(kableExtra)",
+  #   "",
+  #   "res <- check_unused_dependencies(root = '../')",
+  #   "",
+  #   "res |>",
+  #   "  kable() |>",
+  #   "  kable_classic(full_width = FALSE)",
+  #   "",
+  #   "```",
+  #   sep = "\n"
+  # )
+  # write_if_absent(tools_dependencies_qmd_path, tools_dependencies_qmd_text)
+  # 
+  # 
+  # # --- tools/check_unused_objects.qmd ---
+  # tools_unused_objects_qmd_path <- join(project_root, "tools", "check_unused_objects.qmd")
+  # tools_unused_objects_qmd_text <- paste(
+  #   "---",
+  #   'title: "Check if there are unused objects in a project"',
+  #   "format:",
+  #   "  html:",
+  #   "    toc: true",
+  #   "    code-fold: true",
+  #   "execute:",
+  #   "  warning: false",
+  #   "  message: false",
+  #   "---",
+  #   "",
+  #   "When learning to code, it's very easy to accidentally create objects (e.g., data frames) and then never use them in your code. Sometimes, users create 'df2' from 'df1' but, later in the code, go back to calling 'df1'. These 'orphan' objects can represent errors or generally make code confusing - why create an object that is never used?",
+  #   "",
+  #   "This function lets you scan all .qmd, .Rmd, and .R files in your project for unused 'orphan' objects. If you find your project contains them, you should think about whether they're redundant and can be removed, or whether maybe you have an error (e.g., maybe subsequent code should call these objects and not others).",
+  #   "",
+  #   "```{r}",
+  #   "",
+  #   "library(psychdsish)",
+  #   "library(knitr)",
+  #   "library(kableExtra)",
+  #   "",
+  #   "res <- check_unused_objects(root = '../')",
+  #   "",
+  #   "res |>",
+  #   "  kable() |>",
+  #   "  kable_classic(full_width = FALSE)",
+  #   "",
+  #   "```",
+  #   sep = "\n"
+  # )
+  # write_if_absent(tools_unused_objects_qmd_path, tools_unused_objects_qmd_text)
   
   
   # return a summary
@@ -421,13 +455,14 @@ create_project_skeleton <- function(project_root = "../", overwrite = FALSE,
       gitignore_path,
       gitattributes_path,
       file.path(project_root, qmd_files),
-      tools_style_qmd_path,
-      tools_dependencies_qmd_path,
-      tools_unused_objects_qmd_path
+      tools_validator_qmd_path,
+      tools_style_qmd_path
+      # tools_dependencies_qmd_path,
+      # tools_unused_objects_qmd_path
     ),
     type = c(
       rep("dir", length(paths_dir)),
-      "file", "file", "file", "file", "file", rep("file", length(qmd_files)), "file", "file", "file"
+      "file", "file", "file", "file", "file", rep("file", length(qmd_files)), "file", "file"
     )
   )
   invisible(created)

--- a/R/create_project_skeleton.R
+++ b/R/create_project_skeleton.R
@@ -18,6 +18,11 @@
 #'   console.
 #' @param overwrite Logical. If `TRUE`, existing files will be overwritten.
 #'   Defaults to `FALSE`.
+#' @param project_name Character scalar. Name for the dataset. If `NULL` 
+#'   (default), the user will be prompted to enter a name interactively.
+#' @param project_description Character scalar. Description for the dataset. 
+#'   If `NULL` (default), the user will be prompted to enter a description 
+#'   interactively.
 #'
 #' @details
 #' The following directories are created (if not already present):
@@ -43,7 +48,8 @@
 #' The following files are created (if not already present):
 #' \itemize{
 #'   \item `LICENSE` - CC BY 4.0 license text
-#'   \item `README.md` - skeleton README describing project aims and structure
+#'   \item `readme.md` - skeleton README describing project aims and structure
+#'   \item `dataset_description.json` - JSON-LD dataset metadata file
 #'   \item `.gitignore` - ignores R history, session data, caches, temp files,
 #'     OS-specific clutter, and large output directories
 #'   \item `code/analysis.qmd` - Quarto analysis template with metadata, setup
@@ -51,6 +57,10 @@
 #'   \item `code/processing.qmd` - Quarto processing template (same structure)
 #'   \item `tools/style_all_files.qmd` - reproducibility tool to apply
 #'     {tidyverse} code style to all `.qmd`, `.Rmd`, and `.R` files
+#'   \item `tools/detect_unused_dependencies.qmd` - reproducibility tool to
+#'     check whether there are unused dependencies in a project
+#'   \item `tools/detect_unused_objects.qmd` - reproducibility tool to
+#'     check whether there are unused objects in a project
 #' }
 #'
 #' Quarto `.qmd` files are pre-filled with:
@@ -67,11 +77,16 @@
 #'
 #' @examples
 #' \dontrun{
-#' # Create a skeleton in a parent directory
+#' # Create a skeleton in a parent directory with interactive prompts
 #' create_project_skeleton(project_root = "../", overwrite = FALSE)
 #'
-#' # Create in the current working directory and overwrite any existing templates
-#' create_project_skeleton(project_root = ".", overwrite = TRUE)
+#' # Create with specified name and description
+#' create_project_skeleton(
+#'   project_root = ".", 
+#'   overwrite = TRUE,
+#'   project_name = "My Research Study",
+#'   project_description = "A longitudinal study examining cognitive development"
+#' )
 #' 
 #' # Create in a specified directory
 #' create_project_skeleton("~/path/to/github_repository_name", overwrite = FALSE)
@@ -80,13 +95,8 @@
 #' @seealso [psych-DS specification](https://psych-ds.github.io/)
 #'
 #' @export
-
-# \item `tools/detect_unused_dependencies.qmd` - reproducibility tool to
-#   check whether there are unused dependencies in a project
-# \item `tools/detect_unused_objects.qmd` - reproducibility tool to
-#   check whether there are unused objects in a project
-
-create_project_skeleton <- function(project_root = "../", overwrite = FALSE) {
+create_project_skeleton <- function(project_root = "../", overwrite = FALSE, 
+                                    project_name = NULL, project_description = NULL) {
   # minimal dependencies: base R only
   join <- function(...) file.path(..., fsep = .Platform$file.sep)
   mkd  <- function(p) if (!dir.exists(p)) dir.create(p, recursive = TRUE, showWarnings = FALSE)
@@ -99,6 +109,21 @@ create_project_skeleton <- function(project_root = "../", overwrite = FALSE) {
     if (file.exists(path) && !overwrite) return(invisible(FALSE))
     file.create(path)
     invisible(TRUE)
+  }
+  
+  # Prompt for project name and description if not provided
+  if (is.null(project_name)) {
+    project_name <- readline(prompt = "Enter project name: ")
+    if (project_name == "") {
+      project_name <- "Untitled Project"
+    }
+  }
+  
+  if (is.null(project_description)) {
+    project_description <- readline(prompt = "Enter project description: ")
+    if (project_description == "") {
+      project_description <- "No description provided"
+    }
   }
   
   dirs <- c(
@@ -142,7 +167,7 @@ create_project_skeleton <- function(project_root = "../", overwrite = FALSE) {
   # helper for string concatenation
   `%+%` <- function(a, b) paste0(a, b)
   
-  readme_path <- join(project_root, "README.md")
+  readme_path <- join(project_root, "readme.md")
   readme_text <- paste(
     "# Project Title",
     "",
@@ -165,7 +190,7 @@ create_project_skeleton <- function(project_root = "../", overwrite = FALSE) {
       "methods/              # measures, implementations (qualtrics, lab.js, psychopy files, etc.), .docx files with items, etc.\n" %+%
       "preregistration/      # preregistration documents\n" %+%
       "LICENSE               # suggested: CC BY 4.0\n" %+%
-      "README.md             # this file\n" %+%
+      "readme.md             # this file\n" %+%
       "```",
     "",
     "## Reproducibility",
@@ -181,6 +206,19 @@ create_project_skeleton <- function(project_root = "../", overwrite = FALSE) {
     sep = "\n"
   )
   write_if_absent(readme_path, readme_text)
+  
+  # --- dataset_description.json ---
+  dataset_description_path <- join(project_root, "dataset_description.json")
+  dataset_description_text <- paste0(
+    "{\n",
+    '  "@context": "schema.org/",\n',
+    '  "@type": "Dataset",\n',
+    '  "name": "', project_name, '",\n',
+    '  "description": "', project_description, '",\n',
+    '  "variableMeasured": []\n',
+    "}\n"
+  )
+  write_if_absent(dataset_description_path, dataset_description_text)
   
   # --- .gitignore ---
   gitignore_path <- join(project_root, ".gitignore")
@@ -279,36 +317,6 @@ create_project_skeleton <- function(project_root = "../", overwrite = FALSE) {
     write_if_absent(join(project_root, rel), qmd_header(gsub("^code/|\\.qmd$", "", rel)))
   }))
   
-  # --- tools/project_validator.qmd ---
-  tools_validator_qmd_path <- join(project_root, "tools", "project_validator.qmd")
-  tools_validator_qmd_text <- paste(
-    "---",
-    'title: "Check repository compliance against psych-ds-ish standard"',
-    "format:",
-    "  html:",
-    "    toc: true",
-    "    code-fold: true",
-    "execute:",
-    "  warning: false",
-    "  message: false",
-    "---",
-    "",
-    "```{r}",
-    "",
-    "library(psychdsish)",
-    "library(knitr)",
-    "library(kableExtra)",
-    "",
-    'results <- validator("../")',
-    "",
-    "results |>",
-    "  knitr::kable() |>",
-    "  kableExtra::kable_classic(full_width = FALSE)",
-    "```",
-    sep = "\n"
-  )
-  write_if_absent(tools_validator_qmd_path, tools_validator_qmd_text)
-  
   # --- tools/style_all_files.qmd ---
   tools_style_qmd_path <- join(project_root, "tools", "style_all_files.qmd")
   tools_style_qmd_text <- paste(
@@ -335,72 +343,72 @@ create_project_skeleton <- function(project_root = "../", overwrite = FALSE) {
   write_if_absent(tools_style_qmd_path, tools_style_qmd_text)
   
   
-  # # --- tools/detect_unused_dependencies.qmd ---
-  # tools_dependencies_qmd_path <- join(project_root, "tools", "check_unused_dependencies.qmd")
-  # tools_dependencies_qmd_text <- paste(
-  #   "---",
-  #   'title: "Check if there are unused dependencies in a project"',
-  #   "format:",
-  #   "  html:",
-  #   "    toc: true",
-  #   "    code-fold: true",
-  #   "execute:",
-  #   "  warning: false",
-  #   "  message: false",
-  #   "---",
-  #   "",
-  #   "```{r}",
-  #   "",
-  #   "library(psychdsish)",
-  #   "library(knitr)",
-  #   "library(kableExtra)",
-  #   "",
-  #   "res <- check_unused_dependencies(root = '../')",
-  #   "",
-  #   "res |>",
-  #   "  kable() |>",
-  #   "  kable_classic(full_width = FALSE)",
-  #   "",
-  #   "```",
-  #   sep = "\n"
-  # )
-  # write_if_absent(tools_dependencies_qmd_path, tools_dependencies_qmd_text)
-  # 
-  # 
-  # # --- tools/check_unused_objects.qmd ---
-  # tools_unused_objects_qmd_path <- join(project_root, "tools", "check_unused_objects.qmd")
-  # tools_unused_objects_qmd_text <- paste(
-  #   "---",
-  #   'title: "Check if there are unused objects in a project"',
-  #   "format:",
-  #   "  html:",
-  #   "    toc: true",
-  #   "    code-fold: true",
-  #   "execute:",
-  #   "  warning: false",
-  #   "  message: false",
-  #   "---",
-  #   "",
-  #   "When learning to code, it's very easy to accidentally create objects (e.g., data frames) and then never use them in your code. Sometimes, users create 'df2' from 'df1' but, later in the code, go back to calling 'df1'. These 'orphan' objects can represent errors or generally make code confusing - why create an object that is never used?",
-  #   "",
-  #   "This function lets you scan all .qmd, .Rmd, and .R files in your project for unused 'orphan' objects. If you find your project contains them, you should think about whether they're redundant and can be removed, or whether maybe you have an error (e.g., maybe subsequent code should call these objects and not others).",
-  #   "",
-  #   "```{r}",
-  #   "",
-  #   "library(psychdsish)",
-  #   "library(knitr)",
-  #   "library(kableExtra)",
-  #   "",
-  #   "res <- check_unused_objects(root = '../')",
-  #   "",
-  #   "res |>",
-  #   "  kable() |>",
-  #   "  kable_classic(full_width = FALSE)",
-  #   "",
-  #   "```",
-  #   sep = "\n"
-  # )
-  # write_if_absent(tools_unused_objects_qmd_path, tools_unused_objects_qmd_text)
+  # --- tools/detect_unused_dependencies.qmd ---
+  tools_dependencies_qmd_path <- join(project_root, "tools", "check_unused_dependencies.qmd")
+  tools_dependencies_qmd_text <- paste(
+    "---",
+    'title: "Check if there are unused dependencies in a project"',
+    "format:",
+    "  html:",
+    "    toc: true",
+    "    code-fold: true",
+    "execute:",
+    "  warning: false",
+    "  message: false",
+    "---",
+    "",
+    "```{r}",
+    "",
+    "library(psychdsish)",
+    "library(knitr)",
+    "library(kableExtra)",
+    "",
+    "res <- check_unused_dependencies(root = '../')",
+    "",
+    "res |>",
+    "  kable() |>",
+    "  kable_classic(full_width = FALSE)",
+    "",
+    "```",
+    sep = "\n"
+  )
+  write_if_absent(tools_dependencies_qmd_path, tools_dependencies_qmd_text)
+  
+  
+  # --- tools/check_unused_objects.qmd ---
+  tools_unused_objects_qmd_path <- join(project_root, "tools", "check_unused_objects.qmd")
+  tools_unused_objects_qmd_text <- paste(
+    "---",
+    'title: "Check if there are unused objects in a project"',
+    "format:",
+    "  html:",
+    "    toc: true",
+    "    code-fold: true",
+    "execute:",
+    "  warning: false",
+    "  message: false",
+    "---",
+    "",
+    "When learning to code, it's very easy to accidentally create objects (e.g., data frames) and then never use them in your code. Sometimes, users create 'df2' from 'df1' but, later in the code, go back to calling 'df1'. These 'orphan' objects can represent errors or generally make code confusing - why create an object that is never used?",
+    "",
+    "This function lets you scan all .qmd, .Rmd, and .R files in your project for unused 'orphan' objects. If you find your project contains them, you should think about whether they're redundant and can be removed, or whether maybe you have an error (e.g., maybe subsequent code should call these objects and not others).",
+    "",
+    "```{r}",
+    "",
+    "library(psychdsish)",
+    "library(knitr)",
+    "library(kableExtra)",
+    "",
+    "res <- check_unused_objects(root = '../')",
+    "",
+    "res |>",
+    "  kable() |>",
+    "  kable_classic(full_width = FALSE)",
+    "",
+    "```",
+    sep = "\n"
+  )
+  write_if_absent(tools_unused_objects_qmd_path, tools_unused_objects_qmd_text)
   
   
   # return a summary
@@ -409,15 +417,17 @@ create_project_skeleton <- function(project_root = "../", overwrite = FALSE) {
       paths_dir,
       license_path,
       readme_path,
+      dataset_description_path,
+      gitignore_path,
+      gitattributes_path,
       file.path(project_root, qmd_files),
-      tools_validator_qmd_path,
-      tools_style_qmd_path
-      # tools_dependencies_qmd_path,
-      # tools_unused_objects_qmd_path
+      tools_style_qmd_path,
+      tools_dependencies_qmd_path,
+      tools_unused_objects_qmd_path
     ),
     type = c(
       rep("dir", length(paths_dir)),
-      "file", "file", rep("file", length(qmd_files)), "file", "file"
+      "file", "file", "file", "file", "file", rep("file", length(qmd_files)), "file", "file", "file"
     )
   )
   invisible(created)

--- a/R/create_project_skeleton.R
+++ b/R/create_project_skeleton.R
@@ -215,7 +215,7 @@ create_project_skeleton <- function(project_root = "../", overwrite = FALSE,
   dataset_description_path <- join(project_root, "dataset_description.json")
   dataset_description_text <- paste0(
     "{\n",
-    '  "@context": "schema.org/",\n',
+    '  "@context": "https://schema.org/",\n',
     '  "@type": "Dataset",\n',
     '  "name": "', project_name, '",\n',
     '  "description": "', project_description, '",\n',

--- a/R/update_dataset_description_variables.R
+++ b/R/update_dataset_description_variables.R
@@ -1,0 +1,246 @@
+#' Update dataset_description.json with column names from CSV files
+#'
+#' This function scans for CSV files in the data directory (and subdirectories)
+#' that match the psych-ds naming pattern and adds all unique column names to the
+#' variableMeasured array in the dataset_description.json file.
+#'
+#' @param project_root Character scalar. Path to the root directory of the project.
+#'   Defaults to `"../"`
+#'
+#' @details
+#' The function performs the following steps:
+#' \enumerate{
+#'   \item Searches for CSV files matching the pattern `([a-z]+-[a-zA-Z0-9]+)(_[a-z]+-[a-zA-Z0-9]+)*_data\.csv` in the data directory
+#'   \item Reads the header row of each matching CSV file
+#'   \item Collects all unique column names across all files
+#'   \item Reads the existing dataset_description.json file
+#'   \item Updates the variableMeasured array with PropertyValue objects for each new column
+#'   \item Writes the updated JSON back to the file
+#' }
+#'
+#' Each variable is added in the format:
+#' \preformatted{
+#' {
+#'   "@type": "PropertyValue",
+#'   "name": "<column_name>",
+#'   "description": ""
+#' }
+#' }
+#'
+#' Existing variables are preserved - only new variables are added.
+#'
+#' @return
+#' Invisibly returns a list with:
+#' \itemize{
+#'   \item `csv_files_found` - character vector of CSV files that were processed
+#'   \item `variables_added` - character vector of column names that were added
+#'   \item `variables_existing` - character vector of variables that already existed
+#' }
+#'
+#' @examples
+#' \dontrun{
+#' # Update with default settings
+#' update_dataset_description_variables()
+#'
+#' # Update from a specific project directory
+#' update_dataset_description_variables(project_root = "./my_project")
+#' }
+#'
+#' @export
+update_dataset_description_variables <- function(project_root = "../") {
+  
+  # Helper functions
+  join <- function(...) file.path(..., fsep = .Platform$file.sep)
+  
+  # Check if required packages are available, if not use base R alternatives
+  has_jsonlite <- requireNamespace("jsonlite", quietly = TRUE)
+  
+  # Paths
+  data_path <- join(project_root, "data")
+  json_path <- join(project_root, "dataset_description.json")
+  
+  # Check if dataset_description.json exists
+  if (!file.exists(json_path)) {
+    stop("dataset_description.json not found at: ", json_path, 
+         "\nPlease run create_project_skeleton() first or ensure the file exists.")
+  }
+  
+  # Check if data directory exists
+  if (!dir.exists(data_path)) {
+    warning("Data directory not found at: ", data_path)
+    return(invisible(list(
+      csv_files_found = character(0),
+      variables_added = character(0),
+      variables_existing = character(0)
+    )))
+  }
+  
+  # Find CSV files matching the pattern
+  csv_pattern <- "([a-z]+-[a-zA-Z0-9]+)(_[a-z]+-[a-zA-Z0-9]+)*_data\\.csv"
+  all_files <- list.files(data_path, pattern = "\\.csv$", recursive = TRUE, full.names = TRUE)
+  csv_files <- all_files[grepl(csv_pattern, basename(all_files))]
+  
+  if (length(csv_files) == 0) {
+    message("No CSV files found matching pattern: ", csv_pattern)
+    return(invisible(list(
+      csv_files_found = character(0),
+      variables_added = character(0),
+      variables_existing = character(0)
+    )))
+  }
+  
+  message("Found ", length(csv_files), " CSV file(s) matching pattern:")
+  message(paste("  -", basename(csv_files), collapse = "\n"))
+  
+  # Extract column names from all CSV files
+  all_columns <- character(0)
+  
+  for (csv_file in csv_files) {
+    tryCatch({
+      # Read just the header row
+      headers <- names(read.csv(csv_file, nrows = 0, check.names = FALSE))
+      all_columns <- c(all_columns, headers)
+      message("Extracted ", length(headers), " column(s) from: ", basename(csv_file))
+    }, error = function(e) {
+      warning("Could not read CSV file: ", csv_file, " - ", e$message)
+    })
+  }
+  
+  # Get unique column names
+  unique_columns <- unique(all_columns)
+  
+  if (length(unique_columns) == 0) {
+    message("No columns found in CSV files.")
+    return(invisible(list(
+      csv_files_found = basename(csv_files),
+      variables_added = character(0),
+      variables_existing = character(0)
+    )))
+  }
+  
+  message("Found ", length(unique_columns), " unique column name(s):")
+  message(paste("  -", unique_columns, collapse = "\n"))
+  
+  # Read existing JSON file
+  if (has_jsonlite) {
+    json_data <- jsonlite::fromJSON(json_path)
+  } else {
+    # Fallback to base R JSON parsing (basic implementation)
+    json_text <- readLines(json_path, warn = FALSE)
+    json_text <- paste(json_text, collapse = "")
+    
+    json_data <- list()
+    
+    # Extract name
+    name_match <- regmatches(json_text, regexpr('"name"\\s*:\\s*"[^"]*"', json_text))
+    if (length(name_match) > 0) {
+      json_data$name <- gsub('"name"\\s*:\\s*"|"', "", name_match)
+    }
+    
+    # Extract description  
+    desc_match <- regmatches(json_text, regexpr('"description"\\s*:\\s*"[^"]*"', json_text))
+    if (length(desc_match) > 0) {
+      json_data$description <- gsub('"description"\\s*:\\s*"|"', "", desc_match)
+    }
+    
+    # For simplicity, we'll assume variableMeasured is empty or simple
+    json_data$variableMeasured <- list()
+  }
+  
+  # Get existing variable names to avoid duplicates
+  existing_vars <- character(0)
+  
+  if (!is.null(json_data$variableMeasured) && length(json_data$variableMeasured) > 0) {
+    if (has_jsonlite) {
+      # Handle both list and data.frame formats that jsonlite might return
+      if (is.data.frame(json_data$variableMeasured)) {
+        existing_vars <- json_data$variableMeasured$name
+      } else if (is.list(json_data$variableMeasured)) {
+        existing_vars <- sapply(json_data$variableMeasured, function(x) x$name %||% "")
+      }
+    }
+  }
+  
+  # Keep existing variables and add new ones
+  if (has_jsonlite && !is.null(json_data$variableMeasured)) {
+    # Convert data.frame back to list format if needed
+    if (is.data.frame(json_data$variableMeasured)) {
+      new_variables <- apply(json_data$variableMeasured, 1, function(row) {
+        list(
+          `@type` = row[["@type"]],
+          name = row[["name"]],
+          description = row[["description"]]
+        )
+      }, simplify = FALSE)
+    } else {
+      new_variables <- json_data$variableMeasured
+    }
+  } else {
+    new_variables <- list()
+  }
+  
+  # Only add columns that don't already exist
+  columns_to_add <- setdiff(unique_columns, existing_vars)
+  
+  if (length(columns_to_add) == 0) {
+    message("All variables already exist in dataset_description.json")
+    return(invisible(list(
+      csv_files_found = basename(csv_files),
+      variables_added = character(0),
+      variables_existing = existing_vars
+    )))
+  }
+  
+  # Add new variables
+  for (col_name in columns_to_add) {
+    new_var <- list(
+      `@type` = "PropertyValue",
+      name = col_name,
+      description = ""
+    )
+    new_variables[[length(new_variables) + 1]] <- new_var
+  }
+  
+  # Update the JSON data
+  json_data$variableMeasured <- new_variables
+  
+  # Write back to file
+  if (has_jsonlite) {
+    # Use jsonlite for pretty formatting
+    json_text <- jsonlite::toJSON(json_data, pretty = TRUE, auto_unbox = TRUE)
+  } else {
+    # Create JSON manually for base R
+    variables_json <- sapply(new_variables, function(var) {
+      paste0('    {\n',
+             '      "@type": "', var$`@type`, '",\n',
+             '      "name": "', var$name, '",\n',
+             '      "description": "', var$description, '"\n',
+             '    }')
+    })
+    
+    json_text <- paste0(
+      '{\n',
+      '  "@context": "schema.org/",\n',
+      '  "@type": "Dataset",\n',
+      '  "name": "', json_data$name %||% "", '",\n',
+      '  "description": "', json_data$description %||% "", '",\n',
+      '  "variableMeasured": [\n',
+      paste(variables_json, collapse = ",\n"),
+      '\n  ]\n',
+      '}\n'
+    )
+  }
+  
+  writeLines(json_text, json_path)
+  
+  message("Updated dataset_description.json with ", length(columns_to_add), " new variable(s)")
+  
+  invisible(list(
+    csv_files_found = basename(csv_files),
+    variables_added = columns_to_add,
+    variables_existing = existing_vars
+  ))
+}
+
+# Helper function for null coalescing
+`%||%` <- function(a, b) if (is.null(a)) b else a


### PR DESCRIPTION
# Add automated dataset_description.json creation and population

This PR addresses concerns about the difficulty of creating dataset_description.json files by largely automating the process within the existing project skeleton workflow.

I really like what you've made here, and I just want to propose these changes since they would pretty much remove the need for the "-ish" at the end of your project name and allow all of your skeleton templates to be valid Psych-DS datasets.

## Changes:
- Modified `create_project_skeleton()` to prompt for dataset name/description (or accept them as parameters) and generate a basic `dataset_description.json` file
- Added `update_dataset_description_variables()` function that automatically scans CSV files matching the Psych-DS naming pattern and populates the `variableMeasured` field with PropertyValue objects
- Column names from data files are automatically extracted and added as skeleton entries ready for description completion

## Rationale:
Our team is definitely focused on making Psych-DS as simple as possible for researchers to use, but we also think that including metadata is a crucial part of making datasets FAIRer. We have our own R-based dataset converters/template creators in development at the moment, but this package you've put together is really great. It seems like a waste to remove the metadata requirement when the JSON handling can be so easily automated (for instance, our R package has a data dictionary wizard that interactively modifies the variableMeasured array to describe the variables from each CSV in detail.)